### PR TITLE
Enable parsing environment in the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,17 +136,19 @@ The following are parameters supplied to Slurm and must be included in either th
 * `mem`: the memory (in GB) to run each job with.
 * `gres`: the number of "general resources" to request. A 0 value must be supplied if not needed. e.g., `gres = "gpu:0"` must be specified if no GPUs are needed.
 * `constraint`: any constraints e.g., for Milton HPC, you can specify the microarchitecture with `constraint = "Skylake"`.
+* `environment`: a comma-delimited list of key=value pairs to be set with the `--export` option in `sbatch`. E.g., `environment = "LUNCH=sandwich,DINNER=schnitzel"`
 
 Using the `configBWA.toml` example found in the `examples` folder:
 ```
 [jobs]
-cmd="bwa mem -t ${threads} -K 10000000 -R '@RG\\tID:sample_rg1\\tLB:lib1\\tPL:bar\\tSM:sample\\tPU:sample_rg1' ${reference} ${input_path} | gatk SortSam --java-options -Xmx30g --MAX_RECORDS_IN_RAM 250000 -I /dev/stdin -O out.bam --SORT_ORDER coordinate"
+cmd="bwa mem -t ${threads} -K 10000000 -R '@RG\\tID:sample_rg1\\tLB:lib1\\tPL:bar\\tSM:sample\\tPU:sample_rg1' ${reference} ${input_path} | gatk SortSam --java-options -Xmx30g --MAX_RECORDS_IN_RAM 250000 -I /dev/stdin -O out.bam --SORT_ORDER coordinate --TMPDIR $TMPDIR"
 num_reps = 1 
 params_path = "/vast/scratch/users/yang.e/ToolParametriser/examples/IGenricbenchmarking-profiles.csv" 
 tool_type="bwa"
 run_type=""
 email=""
 qos="preempt"
+environment="TMPDIR=/vast/scratch/useres/yang.e"
 ```
 
 * **List of command placeholders**

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The following are parameters supplied to Slurm and must be included in either th
 * `mem`: the memory (in GB) to run each job with.
 * `gres`: the number of "general resources" to request. A 0 value must be supplied if not needed. e.g., `gres = "gpu:0"` must be specified if no GPUs are needed.
 * `constraint`: any constraints e.g., for Milton HPC, you can specify the microarchitecture with `constraint = "Skylake"`.
-* `environment`: a comma-delimited list of key=value pairs to be set with the `--export` option in `sbatch`. E.g., `environment = "LUNCH=sandwich,DINNER=schnitzel"`
+* `environment` (OPTIONAL): a comma-delimited list of key=value pairs to be set with the `--export` option in `sbatch`. E.g., `environment = "LUNCH=sandwich,DINNER=schnitzel"`
 
 Using the `configBWA.toml` example found in the `examples` folder:
 ```

--- a/toolparameteriser/testcreator.py
+++ b/toolparameteriser/testcreator.py
@@ -95,8 +95,10 @@ class AbstractTester(ABC):
             f.write(result)
         logging.info(f"Saved job script to {scriptpath}.")
 
+        envvars = params["environment"]
+
         #RUN if not dryrun
-        cmd = ["sbatch", f"--chdir={scriptdir}", scriptpath]
+        cmd = ["sbatch", f"--chdir={scriptdir}", f"--export={envvars}", scriptpath]
         if self.Config["dryrun"]:
             logging.info(' '.join(cmd))
         else:

--- a/toolparameteriser/testcreator.py
+++ b/toolparameteriser/testcreator.py
@@ -95,10 +95,14 @@ class AbstractTester(ABC):
             f.write(result)
         logging.info(f"Saved job script to {scriptpath}.")
 
-        envvars = params["environment"]
+        
 
         #RUN if not dryrun
-        cmd = ["sbatch", f"--chdir={scriptdir}", f"--export={envvars}", scriptpath]
+        cmd = ["sbatch", f"--chdir={scriptdir}"]
+        if "environment" in params.keys(): 
+            envvars = params["environment"]
+            cmd.append(f"--export={envvars}")
+        cmd.append(scriptpath)
         if self.Config["dryrun"]:
             logging.info(' '.join(cmd))
         else:


### PR DESCRIPTION
@jIskCoder environment variables can optionally be set in either the config file or profile files now with the `environment` parameter, which is a comma-delimited list of key=value pairs. e.g.,

in config file:
```
[jobs]
environment = "ENVVAR1=tomato,ENVVAR1=potato"
... other parameters ...
```
in profile csv:
```
jobname,environment,... other parameter...
job1,"ENVVAR1=hades,ENVVAR2=zeus",...
```
